### PR TITLE
Impossibilitate to vote after time runs out if there is a Timer.

### DIFF
--- a/Blink/Blink/Brainstorming/ViewModels/BrainstormingViewModel.swift
+++ b/Blink/Blink/Brainstorming/ViewModels/BrainstormingViewModel.swift
@@ -27,8 +27,12 @@ class BrainstormingViewModel: NSObject, ObservableObject {
     @Published private(set) var timer: String = ""
 
     var brainstormTimer = Timer()
-
+    
+    /// Variables of Bool type to help in Timer behavior.
+    /// - isTimerActive: Inform if the timer is currently running or not.
+    /// - timeless: Inform if Brainstorm Session is timeless
     @Published var isTimerActive: Bool = true
+    @Published var timeless: Bool = false
     
     /// String array variable to store ideas.
     /// When an idea is sent through P2P connection,
@@ -100,7 +104,7 @@ class BrainstormingViewModel: NSObject, ObservableObject {
     func startBrainstormTimer(counter: Int) {
         
         /// Create a var to put the counter variable in the function scope.
-        var timerCounter = counter * 60 
+        var timerCounter = counter * 60
         var minute: Int = 0
         var second: Int = 0
         
@@ -139,6 +143,7 @@ class BrainstormingViewModel: NSObject, ObservableObject {
                 }
             })
         } else {
+            self.timeless = true
             self.timer = "Without Time Limit"
             self.isTimerActive = false
         }

--- a/Blink/Blink/Brainstorming/Views/BrainstormingView.swift
+++ b/Blink/Blink/Brainstorming/Views/BrainstormingView.swift
@@ -13,16 +13,16 @@ struct BrainstormingView: View {
     
     /// `BrainstormingView`'s viewmodel.
     @ObservedObject var viewmodel: BrainstormingViewModel
-
+    
     @State var newIdea: String = ""
-
+    
     @State var showKeyboard: Bool = false
     
     /// The body of a `BrainstormingView`
     var body: some View {
         VStack {
             Spacer()
-
+            
             /// The HStack containing the topic, timer and
             /// number of ideas added.
             HStack {
@@ -36,31 +36,37 @@ struct BrainstormingView: View {
             }
             Spacer()
             
-
+            
             /// The `GridView` used to layout the ideas in a
             /// 3-column grid.
             GridView(items: self.$viewmodel.ideasMatrix)
             Spacer()
-
+            
             /// The HStack containing the buttons for
             /// adding a new idea, using the Apple TV remote,
             /// and moving forward to voting.
             HStack(alignment: .center) {
-
+                
                 VStack {
-                    /// The Button responsible for adding new ideas
-                    /// using the Apple TV remote.
-                    Button(action: {
-                        self.showKeyboard.toggle()
-                    }) {
-                        HStack(alignment: .center) {
-                            Image(systemName: "plus")
-                            Spacer()
-                            Text("Add")
-                            Spacer()
-                        }.frame(width: 400, height: 50).font(.headline)
+                    /// Conditional to check if timer is active or
+                    /// if the Brainstorm Session is running timeless.
+                    /// This will prompt the view to add or remove the button
+                    /// that adds Ideas.
+                    if self.viewmodel.isTimerActive || self.viewmodel.timeless {
+                        /// The Button responsible for adding new ideas
+                        /// using the Apple TV remote.
+                        Button(action: {
+                            self.showKeyboard.toggle()
+                        }) {
+                            HStack(alignment: .center) {
+                                Image(systemName: "plus")
+                                Spacer()
+                                Text("Add")
+                                Spacer()
+                            }.frame(width: 400, height: 50).font(.headline)
+                        }
                     }
-
+                    
                     if showKeyboard {
                         TextField("Idea", text: self.$newIdea, onEditingChanged: {_ in}) {
                             self.viewmodel.addIdea(self.newIdea)
@@ -69,7 +75,7 @@ struct BrainstormingView: View {
                         }.frame(width: 400, height: 50)
                     }
                 }
-
+                
                 /// The Button responsible for moving forward to
                 /// voting. Should alert the user before moving on.
                 if !viewmodel.isTimerActive {


### PR DESCRIPTION
Fix #35 
**Motivation**: The user could vote after the timer runs out if there is a Timer.

**Modifications**: Created a Bool type var that tells the View if it is running a Brainstorm Session timeless. Also in the BrainstormView created a conditional that checks if the time has run out or it is running in timeless mode. This way the view will add or remove the "Add Idea" button as needed.

**Result**: The user can't vote after the time runs out if there is a Timer active.