### PR TITLE
Show rank in the iOS side app

### DIFF
--- a/Blink/Blink/Ranking/ViewModels/MenuView.swift
+++ b/Blink/Blink/Ranking/ViewModels/MenuView.swift
@@ -31,14 +31,11 @@ struct MenuView: View {
                 Spacer().sheet(isPresented: $viewmodel.isJoining) {
                     Browser(delegate: self.viewmodel)
                 }
-                NavigationLink(destination: BrainstormingView(viewmodel: BrainstormingViewModel()), isActive: $viewmodel.isConnected, label: {EmptyView()})
+                if viewmodel.isConnected {
+                    NavigationLink(destination: BrainstormingView(viewmodel: BrainstormingViewModel()), isActive: $viewmodel.isConnected, label: {EmptyView()})
+                }
             }
         }
     }
 }
 
-struct MenuView_Previews: PreviewProvider {
-    static var previews: some View {
-        MenuView(viewmodel: MenuViewModel() )
-    }
-}

--- a/Blink/Blink/Ranking/Views/RankingView.swift
+++ b/Blink/Blink/Ranking/Views/RankingView.swift
@@ -78,15 +78,15 @@ struct RankingView: View {
             /// The Button responsible for moving back to
             /// the menu. Should alert the user before moving on.
             /// This button works as a NavigationLink.
-            NavigationLink(destination: MenuView(viewmodel: MenuViewModel()), label: {
-                HStack(alignment: .center) {
-                    Image(systemName: "arrow.clockwise")
-                    Spacer()
-                    Text("Restart")
-                    Spacer()
-                }.frame(width: 400, height: 50).font(.headline)
-            })
-            Spacer()
+//            NavigationLink(destination: MenuView(viewmodel: MenuViewModel()), label: {
+//                HStack(alignment: .center) {
+//                    Image(systemName: "arrow.clockwise")
+//                    Spacer()
+//                    Text("Restart")
+//                    Spacer()
+//                }.frame(width: 400, height: 50).font(.headline)
+//            })
+//            Spacer()
         }
     }
 }

--- a/Blink/Blink_iOS/Brainstorming/ViewModels/BrainstormingViewModel.swift
+++ b/Blink/Blink_iOS/Brainstorming/ViewModels/BrainstormingViewModel.swift
@@ -17,12 +17,17 @@ final class BrainstormingViewModel: NSObject, ObservableObject {
 
     @Published var ideas: [Idea] = [Idea]()
     @Published var shouldVote: Bool = false
+    private var shouldDelegate: Bool?
     
     override init() {
         super.init()
-        multipeerConnection.mcSession.delegate = self
+        if let _ = shouldDelegate {
+            os_log("BrainstormingViewModel initialized.", log: .multipeer, type: .info)
+        } else {
+            multipeerConnection.mcSession.delegate = self
+            os_log("BrainstormingViewModel initialized as MCSession's delegate.", log: .multipeer, type: .info)
+        }
 
-        os_log("BrainstormingViewModel initialized as MCSession's delegate.", log: .multipeer, type: .info)
     }
     
     func sendIdea(_ content: String) {
@@ -61,6 +66,7 @@ extension BrainstormingViewModel: MCSessionDelegate {
                 let ideas = try JSONDecoder().decode([Idea].self, from: data)
                 self.ideas = ideas
                 self.shouldVote = true
+                self.shouldDelegate = false
                 os_log("Ideas received. Moving on to voting.", log: .brainstorm, type: .info)
             } catch {
                 os_log("Failed to decode ideas from Mediator to be voted on", log: .voting, type: .error)

--- a/Blink/Blink_iOS/Brainstorming/Views/BrainstormingView.swift
+++ b/Blink/Blink_iOS/Brainstorming/Views/BrainstormingView.swift
@@ -29,9 +29,3 @@ struct BrainstormingView: View {
             }.navigationBarBackButtonHidden(true).padding()
     }
 }
-
-struct BrainstormingView_Previews: PreviewProvider {
-    static var previews: some View {
-        BrainstormingView(viewmodel: BrainstormingViewModel())
-    }
-}

--- a/Blink/Blink_iOS/Ranking/ViewModels/RankingViewModel.swift
+++ b/Blink/Blink_iOS/Ranking/ViewModels/RankingViewModel.swift
@@ -15,13 +15,14 @@ final class RankingViewModel: NSObject, ObservableObject {
     private let multipeerConnection = Multipeer.shared
     
     @Published var topic: String
-    @Published var ranking: [Idea] = []
+    @Published var ranking: [Idea]
     
-    init(topic: String = "") {
+    init(topic: String = "", ranking: [Idea]) {
         self.topic = topic
+        self.ranking = ranking
         super.init()
         multipeerConnection.mcSession.delegate = self
-
+        print(ranking)
         os_log("RankingViewModel initialized as MCSession's delegate.", log: .multipeer, type: .info)
     }
 

--- a/Blink/Blink_iOS/Ranking/Views/RankingView.swift
+++ b/Blink/Blink_iOS/Ranking/Views/RankingView.swift
@@ -43,18 +43,10 @@ struct RankingView: View {
     @ObservedObject var viewmodel: RankingViewModel
 
     var body: some View {
-        NavigationView {
-            List {
-                ForEach(0 ..< viewmodel.ranking.count) { index in
-                    RankingViewRow(index: index + 1, content: self.viewmodel.ranking[index].content, votes: self.viewmodel.ranking[index].votes)
-                }
-            }.navigationBarTitle("Ranking").navigationBarBackButtonHidden(true).padding()
-        }
-    }
-}
-
-struct RankingView_Previews: PreviewProvider {
-    static var previews: some View {
-        RankingView(viewmodel: RankingViewModel())
+        List {
+            ForEach(0 ..< viewmodel.ranking.count) { index in
+                RankingViewRow(index: index + 1, content: self.viewmodel.ranking[index].content, votes: self.viewmodel.ranking[index].votes)
+            }
+        }.navigationBarTitle("Ranking").navigationBarBackButtonHidden(true).padding()
     }
 }

--- a/Blink/Blink_iOS/Voting/ViewModels/VotingViewModel.swift
+++ b/Blink/Blink_iOS/Voting/ViewModels/VotingViewModel.swift
@@ -68,13 +68,16 @@ extension VotingViewModel: MCSessionDelegate {
     
     /// - TODO: Check any necessary changes on p2p for new data structure.
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
-        do {
-            let receivedIdeas = try JSONDecoder().decode([Idea].self, from: data)
-            ideas = receivedIdeas
-            shouldShowRank = true
-            os_log("Ranking received. Moving on to ranking.", log: .voting, type: .info)
-        } catch {
-            os_log("Failed to decode ideas data from mediator.", log: OSLog.voting, type: .error)
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            do {
+                let receivedIdeas = try JSONDecoder().decode([Idea].self, from: data)
+                self.ideas = receivedIdeas
+                self.shouldShowRank = true
+                os_log("Ranking received. Moving on to ranking.", log: .voting, type: .info)
+            } catch {
+                os_log("Failed to decode ideas data from mediator.", log: OSLog.voting, type: .error)
+            }
         }
     }
     

--- a/Blink/Blink_iOS/Voting/Views/VotingView.swift
+++ b/Blink/Blink_iOS/Voting/Views/VotingView.swift
@@ -45,7 +45,7 @@ struct VotingView: View {
                 }.font(.headline)
             }
             if viewmodel.shouldShowRank {
-                NavigationLink(destination: RankingView(viewmodel: RankingViewModel(topic: viewmodel.topic)), isActive: $viewmodel.shouldShowRank, label: {EmptyView().navigationBarItems(trailing: Text("Rank"))})
+                NavigationLink(destination: RankingView(viewmodel: RankingViewModel(topic: viewmodel.topic, ranking: viewmodel.ideas)), isActive: $viewmodel.shouldShowRank, label: {EmptyView().navigationBarItems(trailing: Text("Rank"))})
             }
         }.navigationBarTitle("\(viewmodel.topic)").navigationBarBackButtonHidden(true).padding()
             .navigationBarItems(trailing: Button("Send Votes") {


### PR DESCRIPTION
(Previously Fix #45 was made in a previous commit in another branch)

**Motivation**: Users can't see the idea ranking in their iPhones
**Modifications**: Too much to tell, but in sumary it was made sure that delegates weren't initialized when not needed.
**Results**: Users can see the idea ranking in their phones.