### PR TITLE
Fix menu button returning screen when shouldn't

### DIFF
--- a/Blink/Blink/Brainstorming/Views/BrainstormingView.swift
+++ b/Blink/Blink/Brainstorming/Views/BrainstormingView.swift
@@ -90,6 +90,6 @@ struct BrainstormingView: View {
                 }
             }.padding()
             Spacer()
-        }.navigationBarBackButtonHidden(true)
+            }.navigationBarBackButtonHidden(true).onExitCommand(perform: {})
     }
 }

--- a/Blink/Blink/Menu/Views/MenuView.swift
+++ b/Blink/Blink/Menu/Views/MenuView.swift
@@ -123,12 +123,6 @@ struct MenuView: View {
                 }
                 Spacer()
             }
-        }.navigationBarBackButtonHidden(true)
-    }
-}
-
-struct MenuView_Previews: PreviewProvider {
-    static var previews: some View {
-        MenuView(viewmodel: MenuViewModel())
+            }.navigationBarBackButtonHidden(true).onExitCommand(perform: {})
     }
 }

--- a/Blink/Blink/Ranking/Views/RankingView.swift
+++ b/Blink/Blink/Ranking/Views/RankingView.swift
@@ -101,6 +101,6 @@ struct RankingView: View {
                 })
                 Spacer()
             }
-        }
+        }.onExitCommand(perform: {})
     }
 }

--- a/Blink/Blink/Voting/Views/VotingView.swift
+++ b/Blink/Blink/Voting/Views/VotingView.swift
@@ -56,6 +56,6 @@ struct VotingView: View {
             }).frame(width: 400, height: 50).font(.headline)
 
             Spacer()
-        }.navigationBarBackButtonHidden(true)
+            }.navigationBarBackButtonHidden(true).onExitCommand(perform: {})
     }
 }


### PR DESCRIPTION
Fix #61 
**Motivation**: If you use the Apple TV remote, when you press the menu button a screen goes back.

**Modification**: In all the views it was added a ".onExitCommand" that override the menu button, this way that person can't go back to the previous screen.

**Result**: Now you can't go back to the previous screen when you shouldn't.