### PR TITLE
Improve text handling on iOS in Brainstorm

### DIFF
--- a/Blink/Blink_iOS/Brainstorming/Views/BrainstormingView.swift
+++ b/Blink/Blink_iOS/Brainstorming/Views/BrainstormingView.swift
@@ -18,11 +18,18 @@ struct BrainstormingView: View {
         VStack {
             Text("Brainstorming").foregroundColor(Color("Main")).font(.title).bold().padding()
             TextField("Idea", text: $newIdea).padding()
-            Button(action: {
-                self.viewmodel.sendIdea(self.newIdea)
-            }) {
-                Text("Send").foregroundColor(Color.white).bold()
-            }.padding().background(Color("Main")).cornerRadius(10)
+                .border(Color("Main"), width: 3)
+                .cornerRadius(5)
+            
+            if !newIdea.isEmpty {
+                Button(action: {
+                    self.viewmodel.sendIdea(self.newIdea)
+                    self.newIdea = ""
+                }) {
+                    Text("Send").foregroundColor(Color.white).bold()
+                }.padding().background(Color("Main")).cornerRadius(10)
+            }
+            
             if viewmodel.shouldVote {
                 NavigationLink(destination: VotingView(viewmodel: VotingViewModel(ideas: self.viewmodel.ideas)), isActive: self.$viewmodel.shouldVote, label: {EmptyView().navigationBarItems(trailing: Text("Vote"))})
             }


### PR DESCRIPTION
Fix #66 and Fix #74 

**Motivation**: Text handling on the TextField was enabling users to make mistakes such as sending the same idea twice or sending empty texts.
**Modifications**: Now the button to send your idea only appears when there is a text. Also when you send your idea, the TextField clears itself. To achieve this it was only added some lines of code in the BrainstormingView on the iOS side, such as a conditional to check if there is text on the TextField. It was added a placeholder border to the TextField to help users find it.
**Results**: TextField now has a better behaviour and prevents user from making mistakes.