### PR TITLE
Add feedbacks to the user actions in iOS side

### DIFF
--- a/Blink/Blink/Brainstorming/ViewModels/BrainstormingViewModel.swift
+++ b/Blink/Blink/Brainstorming/ViewModels/BrainstormingViewModel.swift
@@ -106,7 +106,7 @@ class BrainstormingViewModel: NSObject, ObservableObject {
     private func startBrainstormTimer(counter: Int) {
         
         /// Create a var to put the counter variable in the function scope.
-        var timerCounter = 1 * 60
+        var timerCounter = counter * 60
         var minute: Int = 0
         var second: Int = 0
         

--- a/Blink/Blink/Brainstorming/ViewModels/BrainstormingViewModel.swift
+++ b/Blink/Blink/Brainstorming/ViewModels/BrainstormingViewModel.swift
@@ -106,7 +106,7 @@ class BrainstormingViewModel: NSObject, ObservableObject {
     private func startBrainstormTimer(counter: Int) {
         
         /// Create a var to put the counter variable in the function scope.
-        var timerCounter = counter * 60
+        var timerCounter = 1 * 60
         var minute: Int = 0
         var second: Int = 0
         

--- a/Blink/Blink_iOS/Brainstorming/Views/BrainstormingView.swift
+++ b/Blink/Blink_iOS/Brainstorming/Views/BrainstormingView.swift
@@ -12,22 +12,39 @@ struct BrainstormingView: View {
 
     @ObservedObject var viewmodel: BrainstormingViewModel
     @State private var newIdea: String = ""
+    /// Bool type variable that controls the showing of the alert box.
+    /// This alert box is a placeholder feedback. It'll only be used as long
+    /// as there isn't a more suitable option.
+    @State private var showIdeaFeedback: Bool = false
+    /// Bool type variable that refreshes the placeholder text once
+    /// an idea is sent through the press of the button.
+    @State private var refreshPlaceholder: Bool = false
 
 
     var body: some View {
         VStack {
             Text("Brainstorming").foregroundColor(Color("Main")).font(.title).bold().padding()
-            TextField("Idea", text: $newIdea).padding()
+            TextField("Idea" + (refreshPlaceholder ? "" : " "), text: $newIdea).padding()
                 .border(Color("Main"), width: 3)
                 .cornerRadius(5)
             
             if !newIdea.isEmpty {
                 Button(action: {
                     self.viewmodel.sendIdea(self.newIdea)
-                    self.newIdea = ""
+                    self.showIdeaFeedback.toggle()
+                    
                 }) {
                     Text("Send").foregroundColor(Color.white).bold()
                 }.padding().background(Color("Main")).cornerRadius(10)
+                    /// Alert that is created to serve as feedback to inform the user
+                    /// that an idea was sent to the TV.
+                    .alert(isPresented: $showIdeaFeedback) {
+                        Alert(title: Text("Idea Sent!"), message: Text("Your idea was sent to the TV."), dismissButton: .default(Text("Ok!")) {
+                            /// Here the TextField is cleared and the placeholder is refreshed.
+                            self.newIdea = ""
+                            self.refreshPlaceholder.toggle()
+                        })
+                }
             }
             
             if viewmodel.shouldVote {

--- a/Blink/Blink_iOS/Ranking/Views/RankingView.swift
+++ b/Blink/Blink_iOS/Ranking/Views/RankingView.swift
@@ -47,6 +47,6 @@ struct RankingView: View {
             ForEach(0 ..< viewmodel.ranking.count) { index in
                 RankingViewRow(index: index + 1, content: self.viewmodel.ranking[index].content, votes: self.viewmodel.ranking[index].votes)
             }
-        }.navigationBarTitle("Ranking").navigationBarBackButtonHidden(true).padding()
+            }.navigationBarTitle("Ranking").navigationBarBackButtonHidden(true).padding()
     }
 }

--- a/Blink/Blink_iOS/Voting/Views/VotingView.swift
+++ b/Blink/Blink_iOS/Voting/Views/VotingView.swift
@@ -10,53 +10,90 @@ import SwiftUI
 
 struct VotingView: View {
     @ObservedObject var viewmodel: VotingViewModel
-
+    
     @State var currentlyChosen: Idea = Idea(content: "")
-
+    /// Bool type variable that controls if the voting feedback alert box
+    /// should appear or not.
+    @State var showVotingFeedback: Bool = false
+    /// Bool type variable that controls if the alert box that tells
+    /// the user if he has voted or not.
+    @State var showVotedFeedback: Bool = false
+    /// Bool type variable that tells if the user has voted or not.
+    @State var hasVotted: Bool = false
+    
     var body: some View {
-        List {
-            ForEach(0 ..< viewmodel.ideas.count) { index in
-                HStack(alignment: .center) {
-                    Text("\(self.viewmodel.ideas[index].content)")
-                    Spacer()
-                    if self.viewmodel.ideas[index].isSelected {
-                        Button(action: {
-                            self.viewmodel.ideas[index].isSelected.toggle()
-                            self.currentlyChosen = self.viewmodel.ideas[index]
-                            self.currentlyChosen = Idea(content: "")
-                        }, label: {
-                            Image(systemName: "checkmark.circle.fill").foregroundColor(Color("Main"))
-                        })
-                    } else {
-                        Button(action: {
-                            self.viewmodel.ideas[index].isSelected.toggle()
-                            self.viewmodel.ideas = self.viewmodel.ideas.map {
-                                var idea = $0
-                                if $0 == self.currentlyChosen {
-                                    idea.isSelected.toggle()
-                                }
-                                return idea
+        VStack {
+            /// Conditional to check if iOS user has votted or not.
+            if !hasVotted {
+                List {
+                    ForEach(0 ..< viewmodel.ideas.count) { index in
+                        HStack(alignment: .center) {
+                            Text("\(self.viewmodel.ideas[index].content)")
+                            Spacer()
+                            if self.viewmodel.ideas[index].isSelected {
+                                Button(action: {
+                                    self.viewmodel.ideas[index].isSelected.toggle()
+                                    self.currentlyChosen = self.viewmodel.ideas[index]
+                                    self.currentlyChosen = Idea(content: "")
+                                }, label: {
+                                    Image(systemName: "checkmark.circle.fill").foregroundColor(Color("Main"))
+                                })
+                            } else {
+                                Button(action: {
+                                    self.viewmodel.ideas[index].isSelected.toggle()
+                                    self.viewmodel.ideas = self.viewmodel.ideas.map {
+                                        var idea = $0
+                                        if $0 == self.currentlyChosen {
+                                            idea.isSelected.toggle()
+                                        }
+                                        return idea
+                                    }
+                                    self.currentlyChosen = self.viewmodel.ideas[index]
+                                }, label: {
+                                    Image(systemName: "circle").foregroundColor(Color("Main"))
+                                })
                             }
-                            self.currentlyChosen = self.viewmodel.ideas[index]
-                        }, label: {
-                            Image(systemName: "circle").foregroundColor(Color("Main"))
-                        })
+                        }.font(.headline)
                     }
-                }.font(.headline)
+                }
+            } else {
+                /// When user has voted, this View Content will appear while he awaits for the TV
+                /// to go to the Ranking phase.
+                
+                /// This Text is just a placeholder. Final design will be put in its place.
+                VStack(alignment: .center) {
+                    Text("Waiting for TV Mediator to go to ranking phase.")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundColor(Color("Main"))
+                        .padding()
+                }
             }
+            /// The conditional that controls when RankingView should appear on screen.
+            /// It will only activate when the tv goes to its RankingView.
             if viewmodel.shouldShowRank {
                 NavigationLink(destination: RankingView(viewmodel: RankingViewModel(topic: viewmodel.topic, ranking: viewmodel.ideas)), isActive: $viewmodel.shouldShowRank, label: {EmptyView().navigationBarItems(trailing: Text("Rank"))})
             }
-        }.navigationBarTitle("\(viewmodel.topic)").navigationBarBackButtonHidden(true).padding()
+        }
+            /// All the necessary setup and handling for navigation itens.
+            /// Elements such as NavButtons and NavTitles will be configured here
+            .navigationBarTitle("\(viewmodel.topic)").navigationBarBackButtonHidden(true).padding()
             .navigationBarItems(trailing: Button("Send Votes") {
-                self.viewmodel.checkVotedIdeas(self.viewmodel.ideas)
-        }.foregroundColor(Color("Main")))
-    }
-}
-
-
-struct VotingView_Previews: PreviewProvider {
-    static var previews: some View {
-        VotingView(viewmodel: VotingViewModel(ideas: [Idea(content: "Teste"), Idea(content: "Teste2")]))
+                if self.hasVotted == false {
+                    self.viewmodel.checkVotedIdeas(self.viewmodel.ideas)
+                    self.showVotingFeedback.toggle()
+                } else {
+                    self.showVotedFeedback.toggle()
+                }
+            }.foregroundColor(Color("Main")))
+            /// Alert created to provide a feedback to the user so
+            /// he can knows that his idea was sent.
+            .alert(isPresented: $showVotingFeedback) {
+                Alert(title: Text("Vote Sent!"), message: Text("Your vote was sent to the TV"), dismissButton: .default(Text("Ok!")) { self.hasVotted.toggle()
+                    })
+        }
+            /// Alert that tells the user that he has alredy voted.
+            .alert(isPresented: $showVotedFeedback) {
+                Alert(title: Text("Already Voted"), message: Text("You have already voted."), dismissButton: .default(Text("Ok!")))
+        }
     }
 }


### PR DESCRIPTION
Fix #69 and Fix #71 

**Motivation**: The user couldn't know whether his action has resulted in something or not.
**Modification**: Added some Alerts as feedbacks for the user. These alert boxes are just some placeholders for the time being as the final visual design of the app is being made. One modification that was also made was some refactoring and addition of comments in the VotingView of the iOS companion app.
**Results**: Now the users should know that they have executed an action in the iOS app.