### PR TITLE
Add a restart button on iOS side. Minor fix on voting feedback

### DIFF
--- a/Blink/Blink/Brainstorming/ViewModels/BrainstormingViewModel.swift
+++ b/Blink/Blink/Brainstorming/ViewModels/BrainstormingViewModel.swift
@@ -106,7 +106,7 @@ class BrainstormingViewModel: NSObject, ObservableObject {
     private func startBrainstormTimer(counter: Int) {
         
         /// Create a var to put the counter variable in the function scope.
-        var timerCounter = counter * 60
+        var timerCounter = 1 * 60
         var minute: Int = 0
         var second: Int = 0
         

--- a/Blink/Blink/Ranking/ViewModels/MenuView.swift
+++ b/Blink/Blink/Ranking/ViewModels/MenuView.swift
@@ -36,7 +36,7 @@ struct MenuView: View {
                     NavigationLink(destination: BrainstormingView(viewmodel: BrainstormingViewModel()), isActive: $viewmodel.isConnected, label: {EmptyView()})
                 }
             }
-        }
+        }.navigationBarBackButtonHidden(true)
     }
 }
 

--- a/Blink/Blink_iOS/Ranking/Views/RankingView.swift
+++ b/Blink/Blink_iOS/Ranking/Views/RankingView.swift
@@ -12,7 +12,7 @@ struct RankingViewRow: View {
     let index: Int
     let content: String
     let votes: Int
-
+    
     var body: some View {
         HStack {
             if index == 1 {
@@ -41,12 +41,31 @@ struct RankingViewRow: View {
 
 struct RankingView: View {
     @ObservedObject var viewmodel: RankingViewModel
-
+    @State var shouldRestart: Bool = false
+    
     var body: some View {
-        List {
-            ForEach(0 ..< viewmodel.ranking.count) { index in
-                RankingViewRow(index: index + 1, content: self.viewmodel.ranking[index].content, votes: self.viewmodel.ranking[index].votes)
-            }
+        VStack {
+            List {
+                ForEach(0 ..< viewmodel.ranking.count) { index in
+                    RankingViewRow(index: index + 1, content: self.viewmodel.ranking[index].content, votes: self.viewmodel.ranking[index].votes)
+                }
             }.navigationBarTitle("Ranking").navigationBarBackButtonHidden(true).padding()
+            
+            /// Restart button to go back to menu.
+            /// This will make it possible for the user in iOS
+            /// to restart their brainstorming when current one is finished.
+            Button(action: {
+                self.shouldRestart.toggle()
+            }) {
+                Text("Restart")
+                    .bold()
+                    .foregroundColor(.white)
+                    .padding()
+            }
+            .padding()
+            .background(Color("Main"))
+            .cornerRadius(10)
+            NavigationLink(destination: MenuView(viewmodel: MenuViewModel()), isActive: self.$shouldRestart) { EmptyView() }
+        }
     }
 }

--- a/Blink/Blink_iOS/Voting/Views/VotingView.swift
+++ b/Blink/Blink_iOS/Voting/Views/VotingView.swift
@@ -17,7 +17,6 @@ struct VotingView: View {
     @State var showVotingFeedback: Bool = false
     /// Bool type variable that controls if the alert box that tells
     /// the user if he has voted or not.
-    @State var showVotedFeedback: Bool = false
     /// Bool type variable that tells if the user has voted or not.
     @State var hasVotted: Bool = false
     
@@ -81,8 +80,6 @@ struct VotingView: View {
                 if self.hasVotted == false {
                     self.viewmodel.checkVotedIdeas(self.viewmodel.ideas)
                     self.showVotingFeedback.toggle()
-                } else {
-                    self.showVotedFeedback.toggle()
                 }
             }.foregroundColor(Color("Main")))
             /// Alert created to provide a feedback to the user so
@@ -90,10 +87,6 @@ struct VotingView: View {
             .alert(isPresented: $showVotingFeedback) {
                 Alert(title: Text("Vote Sent!"), message: Text("Your vote was sent to the TV"), dismissButton: .default(Text("Ok!")) { self.hasVotted.toggle()
                     })
-        }
-            /// Alert that tells the user that he has alredy voted.
-            .alert(isPresented: $showVotedFeedback) {
-                Alert(title: Text("Already Voted"), message: Text("You have already voted."), dismissButton: .default(Text("Ok!")))
         }
     }
 }


### PR DESCRIPTION
Fix #80 
**Motivation**: User couldn't restart a brainstorm session through the iPhone without restarting his app. This make the UX very unpleasing.
**Modification**: Created a button in the RankingView in the iOS side of the app that creates a NavigationLink when pressed and move to the MenuView
**Results**: User can now go back to the menu screen of the iOS app.