### PR TITLE
Fix faulty restart && Fix brainstorming on iOS when timeless.

### DIFF
--- a/Blink/Blink/Brainstorming/ViewModels/BrainstormingViewModel.swift
+++ b/Blink/Blink/Brainstorming/ViewModels/BrainstormingViewModel.swift
@@ -106,7 +106,7 @@ class BrainstormingViewModel: NSObject, ObservableObject {
     private func startBrainstormTimer(counter: Int) {
         
         /// Create a var to put the counter variable in the function scope.
-        var timerCounter = 1 * 60
+        var timerCounter = counter * 60
         var minute: Int = 0
         var second: Int = 0
         

--- a/Blink/Blink/Brainstorming/Views/BrainstormingView.swift
+++ b/Blink/Blink/Brainstorming/Views/BrainstormingView.swift
@@ -15,7 +15,7 @@ struct BrainstormingView: View {
     @ObservedObject var viewmodel: BrainstormingViewModel
     
     @State var newIdea: String = ""
-    
+    @State var shouldVote: Bool = false
     @State var showKeyboard: Bool = false
     
     /// The body of a `BrainstormingView`
@@ -35,7 +35,7 @@ struct BrainstormingView: View {
                 Spacer()
             }
             Spacer()
-          
+            
             /// The `GridView` used to layout the ideas in a
             /// 3-column grid.
             GridView(items: $viewmodel.ideasMatrix)
@@ -77,19 +77,24 @@ struct BrainstormingView: View {
                 
                 /// The Button responsible for moving forward to
                 /// voting. Should alert the user before moving on.
-                if !viewmodel.isTimerActive {
-                    NavigationLink(destination: VotingView(viewmodel: VotingViewModel(ideas: viewmodel.ideasMatrix, topic: viewmodel.topic)),
-                                   label: {
-                                    HStack(alignment: .center) {
-                                        Image(systemName: "checkmark.circle.fill")
-                                        Spacer()
-                                        Text("Vote")
-                                        Spacer()
-                                    }.frame(width: 400, height: 50).font(.headline)
-                    })
+                Button(action: {
+                    self.shouldVote.toggle()
+                }) {
+                    HStack(alignment: .center) {
+                        Image(systemName: "checkmark.circle.fill")
+                        Spacer()
+                        Text("Vote")
+                        Spacer()
+                    }.frame(width: 400, height: 50).font(.headline)
                 }
+                
+                /// The conditional responsible for creating the NavigationLink
+                if self.shouldVote {
+                    NavigationLink(destination: VotingView(viewmodel: VotingViewModel(ideas: viewmodel.ideasMatrix, topic: viewmodel.topic)), isActive: $shouldVote) { EmptyView() }
+                }
+                
             }.padding()
             Spacer()
-            }.navigationBarBackButtonHidden(true).onExitCommand(perform: {})
+        }.navigationBarBackButtonHidden(true).onExitCommand(perform: {})
     }
 }

--- a/Blink/Blink/Menu/Views/MenuView.swift
+++ b/Blink/Blink/Menu/Views/MenuView.swift
@@ -72,9 +72,9 @@ struct MenuView: View {
                         
                         if selectingTimer {
                             VStack() {
+                                TimerRow(timer: $viewmodel.timer, selectedTimer: $selectingTimer, minutes: 2).frame(height: 50).padding()
+                                TimerRow(timer: $viewmodel.timer, selectedTimer: $selectingTimer, minutes: 5).frame(height: 50).padding()
                                 TimerRow(timer: $viewmodel.timer, selectedTimer: $selectingTimer, minutes: 10).frame(height: 50).padding()
-                                TimerRow(timer: $viewmodel.timer, selectedTimer: $selectingTimer, minutes: 15).frame(height: 50).padding()
-                                TimerRow(timer: $viewmodel.timer, selectedTimer: $selectingTimer, minutes: 20).frame(height: 50).padding()
                             }.frame(width: 400).padding()
                         }
                     }.frame(width: 500)

--- a/Blink/Blink/Ranking/ViewModels/MenuView.swift
+++ b/Blink/Blink/Ranking/ViewModels/MenuView.swift
@@ -9,8 +9,11 @@
 import SwiftUI
 
 struct MenuView: View {
-
+    
     @ObservedObject var viewmodel: MenuViewModel
+    /// This a Bool type var that controls if the Brainstorming
+    /// session has started or not.
+    @State var hasStarted: Bool = false
     
     var body: some View {
         NavigationView {
@@ -25,18 +28,24 @@ struct MenuView: View {
                         .bold()
                         .foregroundColor(.white)
                         .padding()
-                    }
+                }
                 .padding()
                 .background(Color("Main"))
                 .cornerRadius(10)
                 Spacer().sheet(isPresented: $viewmodel.isJoining) {
-                    Browser(delegate: self.viewmodel)
+                    Browser(delegate: self.viewmodel).onDisappear() {
+                        self.hasStarted = true
+                    }
                 }
                 if viewmodel.isConnected {
-                    NavigationLink(destination: BrainstormingView(viewmodel: BrainstormingViewModel()), isActive: $viewmodel.isConnected, label: {EmptyView()})
+                    NavigationLink(destination: BrainstormingView(viewmodel: BrainstormingViewModel(), hasStarted: $hasStarted), isActive: $hasStarted, label: {EmptyView()}).isDetailLink(false)
                 }
             }
-        }.navigationBarBackButtonHidden(true)
+            }.navigationBarBackButtonHidden(true).navigationBarHidden(true)
+            /// This guarantee that the hasStarted var stays false when this view has appeared.
+            .onAppear() {
+                self.hasStarted = false
+        }
     }
 }
 

--- a/Blink/Blink_iOS/Brainstorming/Views/BrainstormingView.swift
+++ b/Blink/Blink_iOS/Brainstorming/Views/BrainstormingView.swift
@@ -19,6 +19,8 @@ struct BrainstormingView: View {
     /// Bool type variable that refreshes the placeholder text once
     /// an idea is sent through the press of the button.
     @State private var refreshPlaceholder: Bool = false
+    /// Binding that has the reference for the State var on the MenuView
+    @Binding var hasStarted: Bool
 
 
     var body: some View {
@@ -48,14 +50,8 @@ struct BrainstormingView: View {
             }
             
             if viewmodel.shouldVote {
-                NavigationLink(destination: VotingView(viewmodel: VotingViewModel(ideas: self.viewmodel.ideas)), isActive: self.$viewmodel.shouldVote, label: {EmptyView().navigationBarItems(trailing: Text("Vote"))})
+                NavigationLink(destination: VotingView(viewmodel: VotingViewModel(ideas: self.viewmodel.ideas), hasStarted: $hasStarted), isActive: self.$viewmodel.shouldVote, label: {EmptyView().navigationBarItems(trailing: Text("Vote"))}).isDetailLink(false)
             }
             }.navigationBarBackButtonHidden(true).padding()
-    }
-}
-
-struct BrainstormingView_Previews: PreviewProvider {
-    static var previews: some View {
-        BrainstormingView(viewmodel: BrainstormingViewModel())
     }
 }

--- a/Blink/Blink_iOS/Ranking/Views/RankingView.swift
+++ b/Blink/Blink_iOS/Ranking/Views/RankingView.swift
@@ -41,7 +41,8 @@ struct RankingViewRow: View {
 
 struct RankingView: View {
     @ObservedObject var viewmodel: RankingViewModel
-    @State var shouldRestart: Bool = false
+    /// Binding that has the reference for the State var on the MenuView
+    @Binding var hasStarted: Bool
     
     var body: some View {
         VStack {
@@ -55,7 +56,7 @@ struct RankingView: View {
             /// This will make it possible for the user in iOS
             /// to restart their brainstorming when current one is finished.
             Button(action: {
-                self.shouldRestart.toggle()
+                self.hasStarted.toggle()
             }) {
                 Text("Restart")
                     .bold()
@@ -65,7 +66,6 @@ struct RankingView: View {
             .padding()
             .background(Color("Main"))
             .cornerRadius(10)
-            NavigationLink(destination: MenuView(viewmodel: MenuViewModel()), isActive: self.$shouldRestart) { EmptyView() }
         }
     }
 }

--- a/Blink/Blink_iOS/Voting/Views/VotingView.swift
+++ b/Blink/Blink_iOS/Voting/Views/VotingView.swift
@@ -19,6 +19,8 @@ struct VotingView: View {
     /// the user if he has voted or not.
     /// Bool type variable that tells if the user has voted or not.
     @State var hasVotted: Bool = false
+    /// Binding that has the reference for the State var on the MenuView
+    @Binding var hasStarted: Bool
     
     var body: some View {
         VStack {
@@ -70,7 +72,7 @@ struct VotingView: View {
             /// The conditional that controls when RankingView should appear on screen.
             /// It will only activate when the tv goes to its RankingView.
             if viewmodel.shouldShowRank {
-                NavigationLink(destination: RankingView(viewmodel: RankingViewModel(topic: viewmodel.topic, ranking: viewmodel.ideas)), isActive: $viewmodel.shouldShowRank, label: {EmptyView().navigationBarItems(trailing: Text("Rank"))})
+                NavigationLink(destination: RankingView(viewmodel: RankingViewModel(topic: viewmodel.topic, ranking: viewmodel.ideas), hasStarted: $hasStarted), isActive: $viewmodel.shouldShowRank, label: {EmptyView().navigationBarItems(trailing: Text("Rank"))}).isDetailLink(false)
             }
         }
             /// All the necessary setup and handling for navigation itens.


### PR DESCRIPTION
Fix #57  
**Motivation**: Earlier restart implemented was creating new NavigationViews and Bars. This was due to the wrong usage of the NavigationLinks that SwiftUI provides.
**Modifications**: It was created a Bool type var in the MenuView that controls if the Brainstorming has started on the iOS, when it starts it is setted to true. This var is passed through the views, and once it reaches the restart button, it toggles back to false and returns to the MenuView.
**Result**: No longer creates an exaggerated amount of Navigation Bars after a few restarts.