### PR TITLE
Fix multiple devices sending idea causing crash && Fix ranking order

### DIFF
--- a/Blink/Blink/Idea.swift
+++ b/Blink/Blink/Idea.swift
@@ -14,12 +14,13 @@ struct Idea: Identifiable {
     var content: String
     var isSelected: Bool = false
     var votes: Int = 0
+    var position: Int = 1
 }
 
 extension Idea: Codable {}
 extension Idea: Hashable {}
 extension Idea: Equatable {
     static func ==(lhs: Idea, rhs: Idea) -> Bool {
-        return lhs.id == rhs.id && lhs.content == rhs.content && lhs.isSelected == rhs.isSelected && lhs.votes == rhs.votes
+        return lhs.id == rhs.id && lhs.content == rhs.content && lhs.isSelected == rhs.isSelected && lhs.votes == rhs.votes && lhs.position == rhs.position
     }
 }

--- a/Blink/Blink/Multipeer.swift
+++ b/Blink/Blink/Multipeer.swift
@@ -32,7 +32,7 @@ final class Multipeer: NSObject, ObservableObject {
     @Published var connectedPeersName: [String] = []
 
     override init() {
-        peerID = MCPeerID(displayName: UIDevice.current.name)
+        peerID = MCPeerID(displayName: "Brainstorm Host \(UIDevice.current.name)")
         mcSession = MCSession(peer: peerID, securityIdentity: nil, encryptionPreference: .required)
         connectionStatus = .notConnected
         mcAdvertiserAssistant = MCAdvertiserAssistant(serviceType: "blnk", discoveryInfo: nil, session: mcSession)

--- a/Blink/Blink/Ranking/ViewModels/RankingViewModel.swift
+++ b/Blink/Blink/Ranking/ViewModels/RankingViewModel.swift
@@ -24,6 +24,7 @@ final class RankingViewModel: NSObject, ObservableObject {
         self.topic = topic
         super.init()
         self.ideas = countVotes(ideas, votedIdeas)
+        self.ideas = giveRankingPosition(self.ideas)
         multipeerConnection.mcSession.delegate = self
 
         os_log("RankingViewModel initialized as MCSession's delegate.", log: .multipeer, type: .info)
@@ -42,6 +43,24 @@ final class RankingViewModel: NSObject, ObservableObject {
             }
             return countedIdea
         }.sorted { $0.votes > $1.votes }
+    }
+    
+    /// This function gives a rank position to the idea based on
+    /// the amount of votes that the idea has. It has the following parameter:
+    /// - Parameter ideas: The Idea type array that will have its positions given.
+    func giveRankingPosition(_ ideas: [Idea]) -> [Idea] {
+        var rankedIdeas = ideas
+        var position = 1
+        
+        for index in 0 ..< rankedIdeas.count {
+            rankedIdeas[index].position = position
+            if index != 0 && rankedIdeas[index].votes == rankedIdeas[index - 1].votes {
+                rankedIdeas[index].position = rankedIdeas[index - 1].position
+            } else {
+                position += 1
+            }
+        }
+        return rankedIdeas
     }
 
     private func sendIdeas() {

--- a/Blink/Blink/Ranking/Views/RankingView.swift
+++ b/Blink/Blink/Ranking/Views/RankingView.swift
@@ -9,28 +9,28 @@
 import SwiftUI
 
 struct RankingViewRow: View {
-    let index: Int
+    let position: Int
     let content: String
     let votes: Int
 
     var body: some View {
         HStack {
-            if index == 1 {
+            if position == 1 {
                 Image(systemName: "rosette")
                     .font(.headline)
                     .foregroundColor(Color.yellow)
-            } else if index == 2 {
+            } else if position == 2 {
                 Image(systemName: "rosette")
                     .font(.headline)
                     .foregroundColor(Color.white)
-            } else if index == 3 {
+            } else if position == 3 {
                 Image(systemName: "rosette")
                     .font(.headline)
                     .foregroundColor(Color.orange)
             } else {
                 Image(systemName: "minus")
             }
-            Text("\(index)").font(.subheadline)
+            Text("\(position)").font(.subheadline)
             Text("\(content)").font(.headline)
             Spacer()
             Text("\(votes)").bold()
@@ -68,7 +68,7 @@ struct RankingView: View {
                 ForEach(0 ..< viewmodel.ideas.count) { index in
                     Button(action: {
                     }) {
-                        RankingViewRow(index: index + 1, content: self.viewmodel.ideas[index].content, votes: self.viewmodel.ideas[index].votes)
+                        RankingViewRow(position: self.viewmodel.ideas[index].position, content: self.viewmodel.ideas[index].content, votes: self.viewmodel.ideas[index].votes)
                         .frame(width: 1000, height: 50)
                     }.padding()
                 }
@@ -78,28 +78,20 @@ struct RankingView: View {
             /// The Button responsible for moving back to
             /// the menu. Should alert the user before moving on.
             /// This button works as a NavigationLink.
+            Button(action: {
+                self.shouldRestart.toggle()
+            }, label: {
+                HStack(alignment: .center) {
+                    Image(systemName: "arrow.clockwise")
+                    Spacer()
+                    Text("Restart")
+                    Spacer()
+                }.frame(width: 400, height: 50).font(.headline)
+            })
+            Spacer()
+            
             if shouldRestart {
-                NavigationLink(destination: MenuView(viewmodel: MenuViewModel()), label: {
-                    HStack(alignment: .center) {
-                        Image(systemName: "arrow.clockwise")
-                        Spacer()
-                        Text("Restart")
-                        Spacer()
-                    }.frame(width: 400, height: 50).font(.headline)
-                })
-                Spacer()
-            } else {
-                Button(action: {
-                    self.shouldRestart.toggle()
-                }, label: {
-                    HStack(alignment: .center) {
-                        Image(systemName: "arrow.clockwise")
-                        Spacer()
-                        Text("Restart?")
-                        Spacer()
-                    }.frame(width: 400, height: 50).font(.headline)
-                })
-                Spacer()
+                NavigationLink(destination: MenuView(viewmodel: MenuViewModel()), isActive: $shouldRestart) { EmptyView() }
             }
         }.onExitCommand(perform: {})
     }

--- a/Blink/Blink_iOS/Idea.swift
+++ b/Blink/Blink_iOS/Idea.swift
@@ -14,12 +14,13 @@ struct Idea: Identifiable {
     var content: String
     var isSelected: Bool = false
     var votes: Int = 0
+    var position: Int = 1
 }
 
 extension Idea: Codable {}
 extension Idea: Hashable {}
 extension Idea: Equatable {
     static func ==(lhs: Idea, rhs: Idea) -> Bool {
-        return lhs.id == rhs.id && lhs.content == rhs.content && lhs.isSelected == rhs.isSelected && lhs.votes == rhs.votes
+        return lhs.id == rhs.id && lhs.content == rhs.content && lhs.isSelected == rhs.isSelected && lhs.votes == rhs.votes && lhs.position == rhs.position
     }
 }

--- a/Blink/Blink_iOS/Ranking/ViewModels/RankingViewModel.swift
+++ b/Blink/Blink_iOS/Ranking/ViewModels/RankingViewModel.swift
@@ -21,9 +21,29 @@ final class RankingViewModel: NSObject, ObservableObject {
         self.topic = topic
         self.ranking = ranking
         super.init()
+        /// Gives a proper rank position to the ideas
+        self.ranking = giveRankingPosition(self.ranking)
         multipeerConnection.mcSession.delegate = self
         print(ranking)
         os_log("RankingViewModel initialized as MCSession's delegate.", log: .multipeer, type: .info)
+    }
+    
+    /// This function gives a rank position to the idea based on
+    /// the amount of votes that the idea has. It has the following parameter:
+    /// - Parameter ideas: The Idea type array that will have its positions given.
+    func giveRankingPosition(_ ideas: [Idea]) -> [Idea] {
+        var rankedIdeas = ideas
+        var position = 1
+        
+        for index in 0 ..< rankedIdeas.count {
+            rankedIdeas[index].position = position
+            if index != 0 && rankedIdeas[index].votes == rankedIdeas[index - 1].votes {
+                rankedIdeas[index].position = rankedIdeas[index - 1].position
+            } else {
+                position += 1
+            }
+        }
+        return rankedIdeas
     }
 
 }

--- a/Blink/Blink_iOS/Ranking/Views/RankingView.swift
+++ b/Blink/Blink_iOS/Ranking/Views/RankingView.swift
@@ -9,28 +9,28 @@
 import SwiftUI
 
 struct RankingViewRow: View {
-    let index: Int
+    let position: Int
     let content: String
     let votes: Int
     
     var body: some View {
         HStack {
-            if index == 1 {
+            if position == 1 {
                 Image(systemName: "rosette")
                     .font(.headline)
                     .foregroundColor(Color.yellow)
-            } else if index == 2 {
+            } else if position == 2 {
                 Image(systemName: "rosette")
                     .font(.headline)
                     .foregroundColor(Color.gray)
-            } else if index == 3 {
+            } else if position == 3 {
                 Image(systemName: "rosette")
                     .font(.headline)
                     .foregroundColor(Color.orange)
             } else {
                 Image(systemName: "minus")
             }
-            Text("\(index)").font(.subheadline)
+            Text("\(position)").font(.subheadline)
             Text("\(content)").font(.headline)
             Spacer()
             Text("\(votes)").bold()
@@ -48,7 +48,7 @@ struct RankingView: View {
         VStack {
             List {
                 ForEach(0 ..< viewmodel.ranking.count) { index in
-                    RankingViewRow(index: index + 1, content: self.viewmodel.ranking[index].content, votes: self.viewmodel.ranking[index].votes)
+                    RankingViewRow(position: self.viewmodel.ranking[index].position, content: self.viewmodel.ranking[index].content, votes: self.viewmodel.ranking[index].votes)
                 }
             }.navigationBarTitle("Ranking").navigationBarBackButtonHidden(true).padding()
             

--- a/Blink/Blink_iOS/Voting/ViewModels/VotingViewModel.swift
+++ b/Blink/Blink_iOS/Voting/ViewModels/VotingViewModel.swift
@@ -13,6 +13,7 @@ import os.log
 final class VotingViewModel: NSObject, ObservableObject {
     
     private var multipeerConnection = Multipeer.shared
+    @Published var inVoting: Bool
     
     @Published var topic: String
     @Published var ideas: [Idea]
@@ -23,6 +24,7 @@ final class VotingViewModel: NSObject, ObservableObject {
          topic: String = "") {
         self.ideas = ideas
         self.topic = topic
+        self.inVoting = true
         super.init()
         multipeerConnection.mcSession.delegate = self
 
@@ -71,10 +73,12 @@ extension VotingViewModel: MCSessionDelegate {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             do {
-                let receivedIdeas = try JSONDecoder().decode([Idea].self, from: data)
-                self.ideas = receivedIdeas
-                self.shouldShowRank = true
-                os_log("Ranking received. Moving on to ranking.", log: .voting, type: .info)
+                if peerID.displayName.contains("Brainstorm Host") {
+                    let receivedIdeas = try JSONDecoder().decode([Idea].self, from: data)
+                    self.ideas = receivedIdeas
+                    self.shouldShowRank = true
+                    os_log("Ranking received. Moving on to ranking.", log: .voting, type: .info)
+                }
             } catch {
                 os_log("Failed to decode ideas data from mediator.", log: OSLog.voting, type: .error)
             }

--- a/Blink/Blink_iOS/Voting/Views/VotingView.swift
+++ b/Blink/Blink_iOS/Voting/Views/VotingView.swift
@@ -88,6 +88,7 @@ struct VotingView: View {
             /// he can knows that his idea was sent.
             .alert(isPresented: $showVotingFeedback) {
                 Alert(title: Text("Vote Sent!"), message: Text("Your vote was sent to the TV"), dismissButton: .default(Text("Ok!")) { self.hasVotted.toggle()
+                    self.viewmodel.inVoting = false
                     })
         }
     }


### PR DESCRIPTION
Fix #93 and Fix #82

**Motivation**: Through testing it was found out that using the app with multiple devices connected caused a crash when sending votes. Another thing that was noted is that ranking wasn't working properly.
**Modifications**: Added a conditional to check if the one who sent the data was the host so the iPhones start the ranking phase in the correct moment. Ranking is now working properly.
**Results**: Everyone should send their votes now without crashing their apps, and ranking is now show correct positions.