### PR TITLE
Adjust the timer format and improve labels

### DIFF
--- a/Blink/Blink/Menu/ViewModels/MenuViewModel.swift
+++ b/Blink/Blink/Menu/ViewModels/MenuViewModel.swift
@@ -14,10 +14,7 @@ final class MenuViewModel: NSObject, ObservableObject {
     
     private lazy var multipeerConnection = Multipeer.shared
 
-    @Published var topic: String = "Choose a topic for your brainstorming session"
-    
-    @Published var timer: Int = 0
-
+    @Published var topic: String = ""
     @Published var isHosting: Bool = false
 
     var anyConnected: Bool {

--- a/Blink/Blink/Menu/Views/MenuView.swift
+++ b/Blink/Blink/Menu/Views/MenuView.swift
@@ -18,7 +18,7 @@ struct MenuView: View {
 
     @State var shouldStart: Bool = false
 
-    @State var timer: String = "00:00"
+    @State var timer: String = ""
     
     /// The body of a `MenuView`.
     var body: some View {
@@ -28,12 +28,12 @@ struct MenuView: View {
                        VStack(alignment: .center) {
                            Spacer()
 
-                        Text(timer)
-                               .font(.system(size: 250, weight: .bold, design: .rounded))
+                        Text("\(timer) min")
+                               .font(.system(size: 225, weight: .bold, design: .rounded))
                                .foregroundColor(Color("Background"))
                                .frame(width: UIScreen.main.bounds.width/2 * 0.8, height: UIScreen.main.bounds.height * 0.42)
 
-                        TextField("Set a timer", text: $timer)
+                        TextField("Set the amount of minutes", text: $timer)
                                .keyboardType(.numberPad)
                                .padding()
                                .frame(width: UIScreen.main.bounds.width/2 * 0.8)
@@ -48,7 +48,7 @@ struct MenuView: View {
                        VStack(alignment: .leading) {
                            Spacer()
 
-                        Text(viewmodel.topic)
+                        Text("Topic: \(viewmodel.topic)")
                                .font(.system(size: 100, weight: .bold, design: .rounded))
                                .foregroundColor(Color("Accent"))
                                .multilineTextAlignment(.leading)
@@ -85,7 +85,7 @@ struct MenuView: View {
                        .frame(width: UIScreen.main.bounds.width/2)
                        .background(Color("Background"))
                 if shouldStart == true {
-                    NavigationLink(destination: BrainstormingView(viewmodel: BrainstormingViewModel(topic: viewmodel.topic, timer: viewmodel.timer)), isActive: self.$shouldStart) { EmptyView() }
+                    NavigationLink(destination: BrainstormingView(viewmodel: BrainstormingViewModel(topic: viewmodel.topic, timer: Int(timer) ?? 0)), isActive: self.$shouldStart) { EmptyView() }
                 }
              }
              .edgesIgnoringSafeArea(.vertical)


### PR DESCRIPTION
**Motivation**: Timer wasn't transformed to int when passed and labels had a strange behaviour sometimes.
**Modifications**: Made a few changes in the menu like decreasing to 225 the timer label font-size. Also the MenuView directly transforms the timer to Int and passes it to the next view.
**Results**: Now timer is, again, properly handled in the menu and labels have a better format.