### PR TITLE
Make it able to vote in more than one idea

### DIFF
--- a/Blink/Blink/Grid/GridViewVotable.swift
+++ b/Blink/Blink/Grid/GridViewVotable.swift
@@ -43,13 +43,6 @@ struct GridViewVotable: View {
                                         self.items[row][col].isSelected.toggle()
                                         self.currentlyChosen = Idea(content: "")
                                     } else {
-                                        self.items = self.items.map { $0.map {
-                                            var idea = $0
-                                            if $0 == self.currentlyChosen {
-                                                idea.isSelected.toggle()
-                                            }
-                                            return idea
-                                            } }
                                         self.items[row][col].isSelected.toggle()
                                         self.currentlyChosen = self.items[row][col]
                                     }

--- a/Blink/Blink_iOS/Voting/Views/VotingView.swift
+++ b/Blink/Blink_iOS/Voting/Views/VotingView.swift
@@ -48,13 +48,6 @@ struct VotingView: View {
                             } else {
                                 Button(action: {
                                     self.viewmodel.ideas[index].isSelected.toggle()
-                                    self.viewmodel.ideas = self.viewmodel.ideas.map {
-                                        var idea = $0
-                                        if $0 == self.currentlyChosen {
-                                            idea.isSelected.toggle()
-                                        }
-                                        return idea
-                                    }
                                     self.currentlyChosen = self.viewmodel.ideas[index]
                                 }, label: {
                                     Image(systemName: "circle")


### PR DESCRIPTION
**Motivation**: The user, both in the iOS and tvOS, could only vote in one idea. This could make the usage of the app not optimal and sometimes frustrating.
**Modification**: Removed both in the GridViewVotable and VotingView in iOS the map function that toggled off the selected idea that would be voted on when another idea is selected.
**Results**: Users can now vote in more than one idea.